### PR TITLE
JS: Missing comma after functions if submodules are present

### DIFF
--- a/dajaxice/templates/dajaxice/dajaxice_core_loop.js
+++ b/dajaxice/templates/dajaxice/dajaxice_core_loop.js
@@ -3,7 +3,7 @@
             {% if function.doc and DAJAXICE_JS_DOCSTRINGS %}/* {{ function.doc|default:'' }}*/ {% endif %}
             {{ function.name }}: function(callback_function, argv, custom_settings){
                 Dajaxice.call('{{function.get_callable_path}}', callback_function, argv, custom_settings);
-            }{% if not forloop.last %},{% endif %}
+            }{% if not forloop.last or module.sub_modules %},{% endif %}
     {% endfor %}
             
     {% for sub_module in module.sub_modules %}


### PR DESCRIPTION
In the template dajaxice_core_loop.js there is no comma inserted after the functions if there are submodules present. This results in invalid JS code. A simple "or" on the presence of submodules when inserting the comma can fix this.
