### PR TITLE
Fixing Some Sphinx Markup in the Docs

### DIFF
--- a/docs/available-settings.rst
+++ b/docs/available-settings.rst
@@ -2,7 +2,7 @@ Available Settings
 ==================
 
 DAJAXICE_MEDIA_PREFIX
------------------------------------
+---------------------
 
 This will be the namespace that dajaxice will use as endpoint.
 
@@ -11,7 +11,7 @@ Defaults to ``dajaxice``
 Optional: ``True``
 
 DAJAXICE_XMLHTTPREQUEST_JS_IMPORT
------------------------------------
+---------------------------------
 
 Include XmlHttpRequest.js inside dajaxice.core.js
 
@@ -20,7 +20,7 @@ Defaults to ``True``
 Optional: ``True``
 
 DAJAXICE_JSON2_JS_IMPORT
------------------------------------
+------------------------
 
 Include json2.js inside dajaxice.core.js
 
@@ -29,7 +29,7 @@ Defaults to ``True``
 Optional: ``True``
 
 DAJAXICE_EXCEPTION
------------------------------------
+------------------
 
 Default data sent when an exception occurs.
 

--- a/docs/custom-error-callbacks.rst
+++ b/docs/custom-error-callbacks.rst
@@ -1,9 +1,9 @@
 Custom error callbacks
-===========================================
+======================
 
 
 How dajaxice handle errors
-------------------------------
+--------------------------
 
 When one of your functions raises an exception dajaxice returns as response the ``DAJAXICE_EXCEPTION`` message.
 On every response ``dajaxice.core.js`` checks if that response was an error or not and shows the user a default
@@ -11,7 +11,7 @@ error message ``Something goes wrong``.
 
 
 Customize the default error message
---------------------------------------
+-----------------------------------
 This behaviour is configurable using the new ``Dajaxice.setup`` function.
 
 .. code-block:: javascript
@@ -19,7 +19,7 @@ This behaviour is configurable using the new ``Dajaxice.setup`` function.
     Dajaxice.setup({'default_exception_callback': function(){ alert('Error!'); }});
 
 Customize error message per call
---------------------------------------
+--------------------------------
 In this new version you can also specify an error callback per dajaxice call.
 
 .. code-block:: javascript

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,9 +1,9 @@
 Installation
-===========================================
+============
 Follow this instructions to start using dajaxice in your django project.
 
 Installing dajaxice
---------------------------
+-------------------
 
 Add `dajaxice` in your project settings.py inside ``INSTALLED_APPS``::
 
@@ -37,7 +37,7 @@ Ensure that ``TEMPLATE_CONTEXT_PROCESSORS`` has ``django.core.context_processors
     )
 
 Configure dajaxice url
-------------------------
+----------------------
 
 Add the following code inside urls.py::
 
@@ -61,7 +61,7 @@ and adding this line to the bottom of your urls.py::
     urlpatterns += staticfiles_urlpatterns()
 
 Install dajaxice in your templates
--------------------------------------
+----------------------------------
 Dajaxice needs some JS to work. To include it in your templates, you should load ``dajaxice_templatetags`` and use ``dajaxice_js_import`` TemplateTag inside your head section. This TemplateTag will print needed js.
 
 .. code-block:: html
@@ -80,5 +80,5 @@ Dajaxice needs some JS to work. To include it in your templates, you should load
 This templatetag will include all the js dajaxice needs.
 
 Use Dajaxice!
---------------------------
+-------------
 Now you can create your first ajax function following the :doc:`quickstart`.

--- a/docs/migrating-to-05.rst
+++ b/docs/migrating-to-05.rst
@@ -11,7 +11,7 @@ Dajaxice ``0.5`` requires ``django>=1.3``, so in order to make dajaxice work you
 
 
 Make django static-files work
-------------------------------
+-----------------------------
 
 Add this at the beginning of your ``urls.py`` file::
 

--- a/docs/production-environment.rst
+++ b/docs/production-environment.rst
@@ -1,5 +1,5 @@
 Production Environment
-=======================
+======================
 
 Since ``0.5`` dajaxice takes advantage of ``django.contrib.staticfiles`` so deploying a dajaxice application live is much easy than in previous versions.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -2,7 +2,7 @@ Quickstart
 ==========
 
 Create your first ajax function
-------------------------------
+-------------------------------
 Create a file named ``ajax.py`` inside any of your apps. For example ``example/ajax.py``.
 
 Inside this file create a simple function that return json.::
@@ -22,7 +22,7 @@ Now you'll need to register this function as a dajaxice function using the ``daj
         return simplejson.dumps({'message':'Hello World'})
 
 Invoque it from your JS
----------------------------
+-----------------------
 
 You can invoque your ajax fuctions from javascript using:
 


### PR DESCRIPTION
This fixes some Sphinx build errors that occur when underlines for titles and
sections aren't the same length as the title itself.
