### PR TITLE
JS: Missing comma after functions if submodules are present (regression)

### DIFF
--- a/dajaxice/templates/dajaxice/dajaxice_function_loop.js
+++ b/dajaxice/templates/dajaxice/dajaxice_function_loop.js
@@ -1,5 +1,5 @@
 {% for function_name, function in module.functions.items %}
     {{ function_name }}: function(callback_function, argv, custom_settings){
         Dajaxice.call('{{ function.name }}', '{{ function.method }}', callback_function, argv, custom_settings);
-    }{% if not forloop.last or top %},{% endif %}
+    }{% if not forloop.last or top or module.submodules %},{% endif %}
 {% endfor %}

--- a/dajaxice/templates/dajaxice/dajaxice_module_loop.js
+++ b/dajaxice/templates/dajaxice/dajaxice_module_loop.js
@@ -4,5 +4,6 @@
     {% with filename="dajaxice/dajaxice_module_loop.js" module=sub_module %}
         {% include filename %}
     {% endwith %}
+    {% if not forloop.last or module.submodules %},{% endif %}
     {% endfor %}
-    }{% if not forloop.last %},{% endif %}
+    }


### PR DESCRIPTION
The placement of commas after functions and modules is not handled correctly if there are submodules present. This was fixed already but seems to have regressed now.

The attached commit adds checks for the presence of submodules in the JS templates.
