### PR TITLE
Jquery dajaxice

### DIFF
--- a/dajaxice/core/__init__.py
+++ b/dajaxice/core/__init__.py
@@ -9,6 +9,7 @@ class DajaxiceConfig(object):
 
     default_config = {'DAJAXICE_XMLHTTPREQUEST_JS_IMPORT': True,
                       'DAJAXICE_JSON2_JS_IMPORT': True,
+                      'DAJAXICE_JS_LIBRARY': 'default',
                       'DAJAXICE_EXCEPTION': 'DAJAXICE_EXCEPTION',
                       'DAJAXICE_MEDIA_PREFIX': 'dajaxice'}
 

--- a/dajaxice/finders.py
+++ b/dajaxice/finders.py
@@ -19,7 +19,6 @@ class VirtualStorage(finders.FileSystemStorage):
             return ''
 
         data = getattr(self, self.files[path])()
-
         try:
             current_file = open(self._files_cache[path])
             current_data = current_file.read()
@@ -28,7 +27,8 @@ class VirtualStorage(finders.FileSystemStorage):
                 os.remove(path)
                 raise Exception("Invalid data")
         except Exception:
-            handle, tmp_path = tempfile.mkstemp()
+            suffix = '.{suf}'.format(suf=path.split('.')[-1]) if '.' in path else ''
+            handle, tmp_path = tempfile.mkstemp(suffix=suffix)
             tmp_file = open(tmp_path, 'w')
             tmp_file.write(data)
             tmp_file.close()

--- a/dajaxice/templates/dajaxice/dajaxice.core.default.js
+++ b/dajaxice/templates/dajaxice/dajaxice.core.default.js
@@ -1,0 +1,45 @@
+{% load url from future %}
+    call: function(dajaxice_function, method, dajaxice_callback, argv, custom_settings)
+    {
+        var custom_settings = custom_settings || {},
+            error_callback = Dajaxice.get_setting('default_exception_callback');
+
+        if('error_callback' in custom_settings && typeof(custom_settings['error_callback']) == 'function'){
+            error_callback = custom_settings['error_callback'];
+        }
+
+        var send_data = 'argv='+encodeURIComponent(JSON.stringify(argv)),
+            oXMLHttpRequest = new XMLHttpRequest,
+            endpoint = '{% url 'dajaxice-endpoint' %}'+dajaxice_function+'/';
+
+        if(method == 'GET'){
+            endpoint = endpoint + '?' + send_data;
+        }
+        oXMLHttpRequest.open(method, endpoint);
+        oXMLHttpRequest.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+        oXMLHttpRequest.setRequestHeader("X-CSRFToken", Dajaxice.get_cookie('csrftoken'));
+        oXMLHttpRequest.onreadystatechange = function() {
+            if (this.readyState == XMLHttpRequest.DONE) {
+                if(this.responseText == Dajaxice.EXCEPTION || !(this.status in Dajaxice.valid_http_responses())){
+                    error_callback();
+                }
+                else{
+                    var response;
+                    try {
+                        response = JSON.parse(this.responseText);
+                    }
+                    catch (exception) {
+                        response = this.responseText;
+                    }
+                    dajaxice_callback(response);
+                }
+            }
+        }
+        if(method == 'POST'){
+            oXMLHttpRequest.send(send_data);
+        }
+        else{
+            oXMLHttpRequest.send();
+        }
+        return oXMLHttpRequest;
+    },

--- a/dajaxice/templates/dajaxice/dajaxice.core.jquery.js
+++ b/dajaxice/templates/dajaxice/dajaxice.core.jquery.js
@@ -1,0 +1,21 @@
+{% load url from future %}
+    call: function(dajaxice_function, method, dajaxice_callback, argv, custom_settings)
+    {
+        var custom_settings = custom_settings || {},
+            error_callback = Dajaxice.get_setting('default_exception_callback');
+
+        if('error_callback' in custom_settings &&
+           typeof(custom_settings['error_callback']) == 'function'){
+            error_callback = custom_settings['error_callback'];
+        }
+
+        jqxhr = $.ajax({
+            url: '{% url 'dajaxice-endpoint' %}'+dajaxice_function+'/',
+            data: 'argv='+encodeURIComponent(JSON.stringify(argv)),
+            dataType: 'json',
+            success: function(data) { dajaxice_callback(data); },
+            headers: { "X-Requested-With": "XMLHttpRequest",
+                       "X-CSRFToken": Dajaxice.get_cookie('csrftoken') },
+        }).error(function(j, t, e) { error_callback(j, t, e); });
+        return jqxhr;
+    },

--- a/dajaxice/templates/dajaxice/dajaxice.core.jquery.js
+++ b/dajaxice/templates/dajaxice/dajaxice.core.jquery.js
@@ -11,6 +11,7 @@
 
         jqxhr = $.ajax({
             url: '{% url 'dajaxice-endpoint' %}'+dajaxice_function+'/',
+            type: method,
             data: 'argv='+encodeURIComponent(JSON.stringify(argv)),
             dataType: 'json',
             success: function(data) { dajaxice_callback(data); },

--- a/dajaxice/templates/dajaxice/dajaxice.core.js
+++ b/dajaxice/templates/dajaxice/dajaxice.core.js
@@ -25,50 +25,9 @@ var Dajaxice = {
         return cookieValue;
     },
 
-    call: function(dajaxice_function, method, dajaxice_callback, argv, custom_settings)
-    {
-        var custom_settings = custom_settings || {},
-            error_callback = Dajaxice.get_setting('default_exception_callback');
-
-        if('error_callback' in custom_settings && typeof(custom_settings['error_callback']) == 'function'){
-            error_callback = custom_settings['error_callback'];
-        }
-
-        var send_data = 'argv='+encodeURIComponent(JSON.stringify(argv)),
-            oXMLHttpRequest = new XMLHttpRequest,
-            endpoint = '{% url 'dajaxice-endpoint' %}'+dajaxice_function+'/';
-
-        if(method == 'GET'){
-            endpoint = endpoint + '?' + send_data;
-        }
-        oXMLHttpRequest.open(method, endpoint);
-        oXMLHttpRequest.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-        oXMLHttpRequest.setRequestHeader("X-CSRFToken", Dajaxice.get_cookie('csrftoken'));
-        oXMLHttpRequest.onreadystatechange = function() {
-            if (this.readyState == XMLHttpRequest.DONE) {
-                if(this.responseText == Dajaxice.EXCEPTION || !(this.status in Dajaxice.valid_http_responses())){
-                    error_callback();
-                }
-                else{
-                    var response;
-                    try {
-                        response = JSON.parse(this.responseText);
-                    }
-                    catch (exception) {
-                        response = this.responseText;
-                    }
-                    dajaxice_callback(response);
-                }
-            }
-        }
-        if(method == 'POST'){
-            oXMLHttpRequest.send(send_data);
-        }
-        else{
-            oXMLHttpRequest.send();
-        }
-        return oXMLHttpRequest;
-    },
+    {% with "dajaxice/dajaxice.core."|add:dajaxice_config.DAJAXICE_JS_LIBRARY|add:".js" as lib %}
+      {% include lib %}
+    {% endwith %}
 
     setup: function(settings)
     {

--- a/dajaxice/templates/dajaxice/dajaxice_function_loop.js
+++ b/dajaxice/templates/dajaxice/dajaxice_function_loop.js
@@ -1,5 +1,5 @@
 {% for function_name, function in module.functions.items %}
     {{ function_name }}: function(callback_function, argv, custom_settings){
-        Dajaxice.call('{{ function.name }}', '{{ function.method }}', callback_function, argv, custom_settings);
+        return Dajaxice.call('{{ function.name }}', '{{ function.method }}', callback_function, argv, custom_settings);
     }{% if not forloop.last or top or module.submodules %},{% endif %}
 {% endfor %}

--- a/dajaxice/tests/__init__.py
+++ b/dajaxice/tests/__init__.py
@@ -137,7 +137,7 @@ class DjangoIntegrationTest(TestCase):
     def test_bad_function(self):
 
         response = self.client.post('/dajaxice/dajaxice.tests.test_ajax_exception/')
-        self.failUnlessEqual(response.status_code, 200)
+        self.failUnlessEqual(response.status_code, 500)
         self.failUnlessEqual(response.content, "DAJAXICE_EXCEPTION")
 
     def test_get_register(self):

--- a/dajaxice/views.py
+++ b/dajaxice/views.py
@@ -48,13 +48,15 @@ class DajaxiceRequest(View):
                 data = {}
 
             # Call the function. If something goes wrong, handle the Exception
+            status = 200
             try:
                 response = function.call(request, **data)
             except Exception:
                 if settings.DEBUG:
                     raise
                 response = dajaxice_config.DAJAXICE_EXCEPTION
+                status = 500
 
-            return HttpResponse(response, mimetype="application/x-json")
+            return HttpResponse(response, status=status, mimetype="application/json")
         else:
             raise FunctionNotCallableError(name)

--- a/docs/available-settings.rst
+++ b/docs/available-settings.rst
@@ -36,3 +36,13 @@ Default data sent when an exception occurs.
 Defaults to ``"DAJAXICE_EXCEPTION"``
 
 Optional: ``True``
+
+DAJAXICE_JS_LIBRARY
+------------------
+
+Library to use for making AJAX calls. By default, XMLHttpRequest is used directly,
+but if you set this to "jquery", jqXHR will be used and returned instead.
+
+Defaults to ``"default"``
+
+Optional: ``True``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Dajaxice has the following aims:
 
 * Isolate the communication between the client and the server.
 * JS Framework agnostic (No Prototype, JQuery... needed ).
+* Special support for frameworks (JQuery, currently) if requested).
 * Presentation logic outside the views (No presentation code inside ajax functions).
 * Lightweight.
 * Crossbrowsing ready.


### PR DESCRIPTION
While I appreciate not needing to have a particular library (such as jquery) installed, for those of us who do, it is nice to have access to things like jQuery.ajax's deferreds.

This patch keeps the original semantics of no-framework by default. However, if you set DAJAXICE_JS_LIBRARY to 'jquery', the underlying Dajaxice.call is replaced with a jQuery-optimized version that returns the jqxhr object.
