### PR TITLE
Django 1.5 compatibility

### DIFF
--- a/dajaxice/templates/dajaxice/dajaxice.core.js
+++ b/dajaxice/templates/dajaxice/dajaxice.core.js
@@ -44,6 +44,7 @@ var Dajaxice = {
         oXMLHttpRequest.open(method, endpoint);
         oXMLHttpRequest.setRequestHeader("X-Requested-With", "XMLHttpRequest");
         oXMLHttpRequest.setRequestHeader("X-CSRFToken", Dajaxice.get_cookie('{{ dajaxice_config.django_settings.CSRF_COOKIE_NAME }}'));
+        oXMLHttpRequest.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
         oXMLHttpRequest.onreadystatechange = function() {
             if (this.readyState == XMLHttpRequest.DONE) {
                 if(this.responseText == Dajaxice.EXCEPTION || !(this.status in Dajaxice.valid_http_responses())){


### PR DESCRIPTION
request.POST will no longer include data posted via HTTP requests with non form-specific content-types in the header. In prior versions, data posted with content-types other than multipart/form-data or application/x-www-form-urlencoded would still end up represented in the request.POST attribute. Developers wishing to access the raw POST data for these cases, should use the request.body attribute instead.

https://docs.djangoproject.com/en/dev/releases/1.5-beta-1/#non-form-data-in-http-requests
