### PR TITLE
Allow HttpResponse objects to be returned from ajax functions

### DIFF
--- a/dajaxice/views.py
+++ b/dajaxice/views.py
@@ -55,6 +55,9 @@ class DajaxiceRequest(View):
                     raise
                 response = dajaxice_config.DAJAXICE_EXCEPTION
 
-            return HttpResponse(response, mimetype="application/x-json")
+            if isinstance(response, basestring):
+                return HttpResponse(response, status=status, mimetype="application/json")
+            else:
+                return response
         else:
             raise FunctionNotCallableError(name)


### PR DESCRIPTION
Allowing HttpResponse objects allows ajax functions (or decorators)
to implement better error handling (such as a 401 for Unauthorized),
which follows the HTTP specification more closely.
