### PR TITLE
Allow HttpResponse objects to be returned from ajax functions

### DIFF
--- a/dajaxice/tests/__init__.py
+++ b/dajaxice/tests/__init__.py
@@ -137,7 +137,7 @@ class DjangoIntegrationTest(TestCase):
     def test_bad_function(self):
 
         response = self.client.post('/dajaxice/dajaxice.tests.test_ajax_exception/')
-        self.failUnlessEqual(response.status_code, 200)
+        self.failUnlessEqual(response.status_code, 500)
         self.failUnlessEqual(response.content, "DAJAXICE_EXCEPTION")
 
     def test_get_register(self):

--- a/dajaxice/views.py
+++ b/dajaxice/views.py
@@ -48,13 +48,18 @@ class DajaxiceRequest(View):
                 data = {}
 
             # Call the function. If something goes wrong, handle the Exception
+            status = 200
             try:
                 response = function.call(request, **data)
             except Exception:
                 if settings.DEBUG:
                     raise
                 response = dajaxice_config.DAJAXICE_EXCEPTION
+                status = 500
 
-            return HttpResponse(response, mimetype="application/x-json")
+            if isinstance(response, basestring):
+                return HttpResponse(response, status=status, mimetype="application/json")
+            else:
+                return response
         else:
             raise FunctionNotCallableError(name)


### PR DESCRIPTION
Allowing HttpResponse objects allows ajax functions (or decorators)
to implement better error handling (such as a 401 for Unauthorized),
which follows the HTTP specification more closely. Make sure that
the proper response codes are being returned for error conditions.
