### PR TITLE
Fix staticfiles finder in Windows failing when STATIC_URL is a full URL

### DIFF
--- a/dajaxice/finders.py
+++ b/dajaxice/finders.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import urllib
 
 from django.contrib.staticfiles import finders
 from django.template import Context
@@ -37,6 +38,7 @@ class VirtualStorage(finders.FileSystemStorage):
         return self._files_cache[path]
 
     def exists(self, name):
+        name = urllib.url2pathname(name)
         return name in self.files
 
     def listdir(self, path):
@@ -51,6 +53,7 @@ class VirtualStorage(finders.FileSystemStorage):
         return folders, files
 
     def path(self, name):
+        name = urllib.url2pathname(name)
         try:
             path = self.get_or_create_file(name)
         except ValueError:


### PR DESCRIPTION
I had a full URL as my STATIC_URL setting (something like http://www.example.com/static/) and I was getting 404s for /static/dajaxice/dajaxice.core.js when testing my site locally (with manage.py runserver). This commit fixed it for me. It seemed to happen because staticfiles.views.serve was handing down to Dajaxice's finder a path with forward slashes, whereas it was expecting a path with backwards slashes.

I had to do a bit of a hack in my urls.py to get staticfiles to serve my files even with a full URL in STATIC_URL (is there a better way? I'm not aware of one), so I guess this isn't a common use case.

```
def extract_path(prefix):
    import urlparse
    prefix = urlparse.urlparse(prefix).path
    if prefix[0] == '/':
        prefix = prefix[1:]
    return prefix

from django.conf.urls.static import static
prefix = extract_path(settings.STATIC_URL)
urlpatterns += static(prefix, view='django.contrib.staticfiles.views.serve')
```
