### PR TITLE
Changes to django.conf.urls import in urls.py

### DIFF
--- a/dajaxice/urls.py
+++ b/dajaxice/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from .views import DajaxiceRequest
 
 urlpatterns = patterns('dajaxice.views',

--- a/dajaxice/urls.py
+++ b/dajaxice/urls.py
@@ -1,8 +1,8 @@
 try: 
-    from django.conf.urls import *
+    from django.conf.urls import url, patterns
 except ImportError: 
     # for Django version less then 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import url, patterns
 from .views import DajaxiceRequest
 
 urlpatterns = patterns('dajaxice.views',

--- a/dajaxice/urls.py
+++ b/dajaxice/urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls import *
+try: 
+    from django.conf.urls import *
+except ImportError: 
+    # for Django version less then 1.4
+    from django.conf.urls.defaults import *
 from .views import DajaxiceRequest
 
 urlpatterns = patterns('dajaxice.views',

--- a/dajaxice/urls.py
+++ b/dajaxice/urls.py
@@ -4,6 +4,7 @@ except ImportError:
     # for Django version less then 1.4
     from django.conf.urls.defaults import url, patterns
 from .views import DajaxiceRequest
+# This commit just to kick a rebuild, since travis somehow got hung up.
 
 urlpatterns = patterns('dajaxice.views',
     url(r'^(.+)/$', DajaxiceRequest.as_view(), name='dajaxice-call-endpoint'),

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='django-dajaxice',


### PR DESCRIPTION
Functions in django.conf.urls.defaults have all moved to django.conf.urls. These changes to urls.py should maintain backwards compatibility with django < 1.4 while eliminating deprecation warnings in 1.5
