### PR TITLE
allow to pass data to error_callback

### DIFF
--- a/dajaxice/templates/dajaxice/dajaxice.core.js
+++ b/dajaxice/templates/dajaxice/dajaxice.core.js
@@ -49,7 +49,11 @@ var Dajaxice = {
         oXMLHttpRequest.onreadystatechange = function() {
             if (this.readyState == XMLHttpRequest.DONE) {
                 if(this.responseText == Dajaxice.EXCEPTION || !(this.status in Dajaxice.valid_http_responses())){
-                    error_callback();
+                    if('error_callback_argv' in custom_settings) {
+                        error_callback(custom_settings['error_callback_argv']);
+                    } else {
+                        error_callback();
+                    }
                 }
                 else{
                     var response;


### PR DESCRIPTION
I had a need to pass extra information to the error callback. I think this can be useful.

``` javascript
function custom_error(data){
    alert('Custom error of my_function. user = ' + data['user']);
}

Dajaxice.simple.my_function(
    callback, 
    {'user': 'tom'}, 
    {'error_callback': custom_error, 'error_callback_argv' :{'user' : 'tom'}}
);
```
