### PR TITLE
Dajaxice is not discovering ajax.py modules in the main django entry point.

### DIFF
--- a/dajaxice/core/Dajaxice.py
+++ b/dajaxice/core/Dajaxice.py
@@ -120,7 +120,10 @@ def dajaxice_autodiscover():
     import imp
     from django.conf import settings
 
-    for app in settings.INSTALLED_APPS:
+    app = settings.ROOT_URLCONF.split('.', 1)[0]
+    apps = settings.INSTALLED_APPS+(app,)
+
+    for app in apps:
 
         try:
             app_path = import_module(app).__path__


### PR DESCRIPTION
this patch allows to load ajax.py module from the main project entry
    point, where settings.ROOT_URLCONF is located.
