### PR TITLE
Add DAJAXICE_FETCH_CSRF_FROM_FIELD in order to avoid reading CSRF cookie

### DIFF
--- a/dajaxice/templates/dajaxice/dajaxice.core.js
+++ b/dajaxice/templates/dajaxice/dajaxice.core.js
@@ -26,6 +26,15 @@ var Dajaxice = {
         return cookieValue;
     },
 
+    get_csrf_id: function()
+    {
+    {% if dajaxice_config.DAJAXICE_FETCH_CSRF_FROM_FIELD %}
+        return document.getElementsByName('csrfmiddlewaretoken')[0].value;
+    {% else %}
+	    return Dajaxice.get_cookie('{{ dajaxice_config.django_settings.CSRF_COOKIE_NAME }}')
+    {% endif %}
+    },
+
     call: function(dajaxice_function, method, dajaxice_callback, argv, custom_settings)
     {
         var custom_settings = custom_settings || {},
@@ -45,7 +54,7 @@ var Dajaxice = {
         oXMLHttpRequest.open(method, endpoint);
         oXMLHttpRequest.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
         oXMLHttpRequest.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-        oXMLHttpRequest.setRequestHeader("X-CSRFToken", Dajaxice.get_cookie('{{ dajaxice_config.django_settings.CSRF_COOKIE_NAME }}'));
+        oXMLHttpRequest.setRequestHeader("X-CSRFToken", Dajaxice.get_csrf_id());
         oXMLHttpRequest.onreadystatechange = function() {
             if (this.readyState == XMLHttpRequest.DONE) {
                 if(this.responseText == Dajaxice.EXCEPTION || !(this.status in Dajaxice.valid_http_responses())){

--- a/docs/available-settings.rst
+++ b/docs/available-settings.rst
@@ -36,3 +36,12 @@ Default data sent when an exception occurs.
 Defaults to ``"DAJAXICE_EXCEPTION"``
 
 Optional: ``True``
+
+DAJAXICE_FETCH_CSRF_FROM_FIELD
+------------------------------
+
+Should we fetch the CSRF token from a form field? If False, then fetch from cookie.
+
+Defaults to ``False``
+
+Optional: ``True``


### PR DESCRIPTION
A security recommendation is to mark all cookies httponly which disallows javascript from reading the cookies. This causes problems with dajaxice. This change adds a configuration option to pull the CSRF token from the form field rather than the cookie.
