### PR TITLE
Python 3 issues

### DIFF
--- a/dajaxice/core/__init__.py
+++ b/dajaxice/core/__init__.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from Dajaxice import Dajaxice, dajaxice_autodiscover
+from .Dajaxice import Dajaxice, dajaxice_autodiscover
 
 
 class DajaxiceConfig(object):

--- a/dajaxice/views.py
+++ b/dajaxice/views.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from django.utils import simplejson
+from django.utils import simplejson, six
 from django.views.generic.base import View
 from django.http import HttpResponse, Http404
 
@@ -9,19 +9,6 @@ from dajaxice.exceptions import FunctionNotCallableError
 from dajaxice.core import dajaxice_functions, dajaxice_config
 
 log = logging.getLogger('dajaxice')
-
-
-def safe_dict(d):
-    """
-    Recursively clone json structure with UTF-8 dictionary keys
-    http://www.gossamer-threads.com/lists/python/bugs/684379
-    """
-    if isinstance(d, dict):
-        return dict([(k.encode('utf-8'), safe_dict(v)) for k, v in d.iteritems()])
-    elif isinstance(d, list):
-        return [safe_dict(x) for x in d]
-    else:
-        return d
 
 
 class DajaxiceRequest(View):
@@ -40,10 +27,7 @@ class DajaxiceRequest(View):
 
             # Clean the argv
             if data != 'undefined':
-                try:
-                    data = safe_dict(simplejson.loads(data))
-                except Exception:
-                    data = {}
+                data = simplejson.loads(data)
             else:
                 data = {}
 


### PR DESCRIPTION
I'm trying to run dajaxice under python 3, and here I've fixed 2 issues.
1. Import error (python 3 requires explicit relative imports)
2. There is no need for safe_dict at all. Even python 2.6 can accept unicode keys in kwargs. You can check this here http://stackoverflow.com/questions/4598604/ . In py3, this function makes binary keys instead of strings and entirely blocks parameter passing.
