### PR TITLE
removed .defaults from imports in urls.py

### DIFF
--- a/dajaxice/urls.py
+++ b/dajaxice/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from .views import DajaxiceRequest
 
 urlpatterns = patterns('dajaxice.views',

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,6 @@ setup(
                       "doesn't require any JS Framework. Dajaxice uses the "
                       "unobtrusive standard-compliant (W3C) XMLHttpRequest "
                       "1.0 object."),
-    install_requires=[
-        'Django>=1.3'
-    ],
     classifiers=['Development Status :: 4 - Beta',
                 'Environment :: Web Environment',
                 'Framework :: Django',


### PR DESCRIPTION
django.conf.urls.defaults is depreciated in Django 1.6
