### PR TITLE
Changed the URL import to django.conf.urls

### DIFF
--- a/dajaxice/urls.py
+++ b/dajaxice/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from .views import DajaxiceRequest
 
 urlpatterns = patterns('dajaxice.views',


### PR DESCRIPTION
This is because of:
django.conf.urls.defaults is deprecated; use django.conf.urls instead
