### PR TITLE
Enabled setting cookies in dajax views

### DIFF
--- a/dajaxice/views.py
+++ b/dajaxice/views.py
@@ -55,8 +55,11 @@ class DajaxiceRequest(View):
                     raise
                 response = dajaxice_config.DAJAXICE_EXCEPTION
             if django.get_version() >= '1.7':
-                return HttpResponse(response, content_type="application/x-json")
+                res = HttpResponse(response, content_type="application/x-json")
             else:
-                return HttpResponse(response, mimetype="application/x-json")
+                res = HttpResponse(response, mimetype="application/x-json")
+            if response != dajaxice_config.DAJAXICE_EXCEPTION:
+                res.cookies = response.cookies
+            return res
         else:
             raise FunctionNotCallableError(name)


### PR DESCRIPTION
For now, when we set cookie from a dajax view, it is being ignored when doing the following in dispatch view:

``` python
if django.get_version() >= '1.7':
     return HttpResponse(response, content_type="application/x-json")
else:
     return HttpResponse(response, mimetype="application/x-json")
```

So I fixed it by copying response's cookies in new responses objects.
