### PR TITLE
proper way to include import_module

### DIFF
--- a/dajaxice/core/Dajaxice.py
+++ b/dajaxice/core/Dajaxice.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.utils.importlib import import_module
+from importlib import import_module
 
 log = logging.getLogger('dajaxice')
 


### PR DESCRIPTION
fixes Django-1.9 compatibility
